### PR TITLE
fixed simple boolean values declaration bug

### DIFF
--- a/Lang.Tests/LangTests.cs
+++ b/Lang.Tests/LangTests.cs
@@ -1551,5 +1551,20 @@ person.methodProxy(fun(string i) -> { print i + 'proxy'; });
 
             Console.WriteLine("Original declared return expression type: " + function.MethodReturnType);
         }
+
+          [Test]
+        public void TestBooleanValuesDeclaration()
+        {
+            var test = @"bool flag = true;";
+
+            var ast = (new LanguageParser(new Lexers.Lexer(test)).Parse() as ScopeDeclr);
+
+            var expr = (ast.ScopedStatements[0] as Expr);
+
+            Assert.IsTrue(ast.ScopedStatements[0] is VarDeclrAst);
+            Assert.IsTrue(expr.Right.Token.TokenType == TokenType.Boolean);
+
+
+        }
     }
 }

--- a/Lang/Utils/ScopeUtil.cs
+++ b/Lang/Utils/ScopeUtil.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -64,6 +64,8 @@ namespace Lang.Utils
                         case TokenType.Word:
                             return new UserDefinedType(astType.Token.TokenValue);
                         case TokenType.True:
+                        case TokenType.Boolean:
+                            return new BuiltInType(ExpressionTypes.Boolean);
                         case TokenType.False:
                             return new BuiltInType(ExpressionTypes.Boolean);
                         case TokenType.Method:

--- a/Lang/Utils/ScopeUtil.cs
+++ b/Lang/Utils/ScopeUtil.cs
@@ -63,10 +63,9 @@ namespace Lang.Utils
                             return new BuiltInType(ExpressionTypes.String);
                         case TokenType.Word:
                             return new UserDefinedType(astType.Token.TokenValue);
-                        case TokenType.True:
                         case TokenType.Boolean:
-                            return new BuiltInType(ExpressionTypes.Boolean);
                         case TokenType.False:
+                        case TokenType.True:
                             return new BuiltInType(ExpressionTypes.Boolean);
                         case TokenType.Method:
                             return new BuiltInType(ExpressionTypes.Method);


### PR DESCRIPTION
idk why, but, the return for BuiltInType boolean was missing, so, fixed it 👯 

![](https://i.imgur.com/XMiy7K9.png)

If we try to declare a bool var with a value or try to assign a value to it, a exception is thrown

```csharp
bool flag = false;

or

bool flag;
flag = true;
```

Throws this exception:

`Exceção Sem Tratamento: System.NullReferenceException: Referência de objeto não definida para uma instância de um objeto.
   em Lang.Visitors.ScopeBuilderVisitor.Visit(VarDeclrAst ast) na C:\Users\Luan\Desktop\lang\Lang\Visitors\ScopeBuilderVisitor.cs:linha 399
   em Lang.AST.VarDeclrAst.Visit(IAstVisitor visitor) na C:\Users\Luan\Desktop\lang\Lang\AST\VarDeclrAst.cs:linha 45
   em Lang.Visitors.ScopeBuilderVisitor.<Visit>b__37_0(Ast statement) na C:\Users\Luan\Desktop\lang\Lang\Visitors\ScopeBuilderVisitor.cs:linha 514
   em System.Collections.Generic.List`1.ForEach(Action`1 action)
   em Lang.Visitors.ScopeBuilderVisitor.Visit(ScopeDeclr ast) na C:\Users\Luan\Desktop\lang\Lang\Visitors\ScopeBuilderVisitor.cs:linha 514
   em Lang.AST.ScopeDeclr.Visit(IAstVisitor visitor) na C:\Users\Luan\Desktop\lang\Lang\AST\ScopeDeclr.cs:linha 22
   em Lang.Visitors.ScopeBuilderVisitor.Start(Ast ast) na C:\Users\Luan\Desktop\lang\Lang\Visitors\ScopeBuilderVisitor.cs:linha 614
   em Lang.Visitors.InterpretorVisitor.Start(Ast ast) na C:\Users\Luan\Desktop\lang\Lang\Visitors\InterpretorVisitor.cs:linha 91
   em Interpreter.Program.Main(String[] args) na C:\Users\Luan\Desktop\lang\Interpreter\Program.cs:linha 30`

This is caused becuase TokenType Boolean has no BuiltInType return.

After changing this:
```csharp
case TokenType.True:
case TokenType.False:
        return new BuiltInType(ExpressionTypes.Boolean);
```

To this:

```csharp
case TokenType.Boolean:
case TokenType.False:
case TokenType.True:
        return new BuiltInType(ExpressionTypes.Boolean);
```

Now we can run

```csharp
bool flag = false;
print flag;
```

It will output

```csharp
False
```
